### PR TITLE
Tests for cookbook

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+-f documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+Encoding:
+  Enabled: False
+LineLength:
+  Max: 250
+Documentation:
+  Enabled: False
+HashSyntax:
+  Enabled: False
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+AsciiComments:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+language: ruby
+rvm:
+  - 1.9.3
+cache: bundler
+sudo: false
+bundler_args: --jobs 7 --without docs integration
+script: bundle exec rake

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,7 @@
+source 'https://supermarket.chef.io'
+
+group :integration do
+  cookbook 'minitest-handler'
+end
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf', '~> 3.0'
+gem 'foodcritic', '~> 3.0'
+
+gem 'chefspec', '~> 4.0'
+gem 'rspec', '~> 3.0'
+
+gem 'rubocop'
+gem 'rubocop-checkstyle_formatter', require: false
+gem 'rainbow', '<= 1.99.1'
+
+group :integration do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,54 @@
+#!/usr/bin/env rake
+
+require 'bundler/setup'
+
+# chefspec task against spec/*_spec.rb
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:chefspec)
+
+# foodcritic rake task
+desc 'Foodcritic linter'
+task :foodcritic do
+  sh 'foodcritic -f correctness .'
+end
+
+# rubocop rake task
+desc 'Ruby style guide linter'
+task :rubocop do
+  sh 'rubocop -D'
+end
+
+# creates metadata.json
+desc 'Create metadata.json from metadata.rb'
+task :metadata do
+  sh 'knife cookbook metadata from file metadata.rb'
+end
+
+# share cookbook to Chef community site
+desc 'Share cookbook to community site'
+task :share do
+  sh 'knife cookbook site share coopr other'
+end
+
+# run vagrant test
+desc 'Run vagrant tests'
+task :vagrant do
+  sh 'vagrant up'
+end
+
+# test-kitchen
+begin
+  require 'kitchen/rake_tasks'
+  desc 'Run Test Kitchen integration tests'
+  task :integration do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end
+
+# default tasks are quick, commit tests
+task :default => %w(foodcritic rubocop chefspec)

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ end
 # share cookbook to Chef community site
 desc 'Share cookbook to community site'
 task :share do
-  sh 'knife cookbook site share coopr other'
+  sh 'knife cookbook site share impala databases'
 end
 
 # run vagrant test

--- a/spec/catalog_spec.rb
+++ b/spec/catalog_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'impala::catalog' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs impala-catalog package' do
+      expect(chef_run).to install_package('impala-catalog')
+    end
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -16,5 +16,9 @@ describe 'impala::default' do
     it 'create impala group' do
       expect(chef_run).to create_group('impala')
     end
+
+    it 'installs impala package' do
+      expect(chef_run).to install_package('impala')
+    end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'impala::default' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'creates impala user' do
+      expect(chef_run).to create_user('impala')
+    end
+
+    it 'create impala group' do
+      expect(chef_run).to create_group('impala')
+    end
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -13,7 +13,7 @@ describe 'impala::default' do
       expect(chef_run).to create_user('impala')
     end
 
-    it 'create impala group' do
+    it 'creates impala group' do
       expect(chef_run).to create_group('impala')
     end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'impala::server' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs impala-server package' do
+      expect(chef_run).to install_package('impala-server')
+    end
+  end
+end

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'impala::shell' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs impala-shell package' do
+      expect(chef_run).to install_package('impala-shell')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/state_store_spec.rb
+++ b/spec/state_store_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'impala::state_store' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'installs impala-state-store package' do
+      expect(chef_run).to install_package('impala-state-store')
+    end
+  end
+end


### PR DESCRIPTION
Adds ChefSpec and rubocop tests. Current coverage is 100%, minus `config.rb` which will be done in the `feature/config` branch.

```
ChefSpec Coverage report generated...
  Total Resources:   9
  Touched Resources: 7
  Touch Coverage:    77.78%

Untouched Resources:
  directory[/etc/impala/conf.chef]   impala/recipes/config.rb:22
  execute[update impala-conf alternatives]   impala/recipes/config.rb:31
```