### PR TITLE
COOK-20 Using override sets precidence too high

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+gem 'chef', '< 12.0'
+
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -25,8 +25,8 @@ default['impala']['user'] = 'impala'
 default['impala']['group'] = 'impala'
 
 # Set Hadoop attributes
-override['hadoop']['distribution'] = 'cdh'
-override['hadoop']['distribution_version'] = 5
+default['hadoop']['distribution'] = 'cdh'
+default['hadoop']['distribution_version'] = 5
 
 # These are required to be set for Impala
 # http://www.cloudera.com/content/cloudera/en/documentation/cloudera-impala/latest/topics/impala_config_performance.html


### PR DESCRIPTION
Since we validate the values, there's no reason to set them at anything higher than default. This fixes COOK-20