### PR TITLE
Update testing framework and cleanup syntax

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,19 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        ruby:
+          mass_threshold: 20
+  fixme:
+    enabled: true
+  foodcritic:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,27 @@ LineLength:
   Max: 600
 Documentation:
   Enabled: False
-HashSyntax:
-  Enabled: False
+AsciiComments:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
 Style/SpaceBeforeFirstArg:
   Enabled: false
-AsciiComments:
+Style/SymbolArray:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014-2016 Cask Data, Inc.
+# Copyright © 2014-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +17,8 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
   - 2.1.4
+  - 2.3.1
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,13 @@
 source 'https://supermarket.chef.io'
 
+require 'chef/version'
+
 if Chef::VERSION.to_f < 12.0
   cookbook 'apt', '< 4.0'
+  cookbook 'ark', '< 3.0'
   cookbook 'build-essential', '< 3.0'
   cookbook 'homebrew', '< 3.0'
+  cookbook 'java', '< 1.48'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
@@ -12,6 +16,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'yum-epel', '< 2.0'
 elsif Chef::VERSION.to_f < 12.5
   cookbook 'apt', '< 6.0'
+  cookbook 'ark', '< 3.0'
   cookbook 'build-essential', '< 8.0'
   cookbook 'mingw', '< 2.0'
   cookbook 'ohai', '< 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ if RUBY_VERSION.to_f < 2.0
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
+elsif RUBY_VERSION.to_f >= 2.3
+  gem 'chef'
+  gem 'foodcritic'
+  gem 'rubocop'
 else
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'

--- a/Rakefile
+++ b/Rakefile
@@ -51,4 +51,4 @@ rescue LoadError
 end
 
 # default tasks are quick, commit tests
-task :default => %w(foodcritic rubocop chefspec)
+task default: %w(foodcritic rubocop chefspec)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'impala'
 maintainer       'Cask Data, Inc.'
 maintainer_email 'ops@cask.co'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Installs/Configures Impala'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
@@ -16,3 +16,4 @@ end
 
 source_url 'https://github.com/caskdata/impala_cookbook' if respond_to?(:source_url)
 issues_url 'https://issues.cask.co/browse/COOK/component/10613' if respond_to?(:issues_url)
+chef_version '>= 11' if respond_to?(:chef_version)

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -71,7 +71,7 @@ if node['impala'].key?('config')
     owner node['impala']['user']
     group node['impala']['group']
     action :create
-    variables :options => node['impala']['config']
+    variables options: node['impala']['config']
   end
 end # End /etc/default/impala
 
@@ -82,7 +82,7 @@ template "#{impala_conf_dir}/hive-site.xml" do
   owner node['impala']['user']
   group node['impala']['group']
   action :create
-  variables :options => node['hive']['hive_site']
+  variables options: node['hive']['hive_site']
   only_if { node.key?('hive') && node['hive'].key?('hive_site') && !node['hive']['hive_site'].empty? }
 end # End hive-site.xml
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 at_exit { ChefSpec::Coverage.report! }
+
+RSpec.configure do |config|
+  config.log_level = :error
+end


### PR DESCRIPTION
This updates the testing framework and does some minor cleanup.

- Copy files from caskdata/cdap_cookbook
  - `.codeclimate.yml`
  - `.rubocop.yml`
  - `.travis.yml`
  - `Berksfile`
  - `spec/spec_helper.rb`
- Test latest Chef by adding Ruby 2.3.1 to Travis configuration and Gemfile
- Remove Ruby 2.0 from Travis configuration as it was (mostly) redundant with 2.1
- Add `require 'chef/version'` to Berksfile
- Add `chef_version` to metadata
- Switch to Ruby 1.9+ hash syntax